### PR TITLE
Remove Cache.php destructor

### DIFF
--- a/src/Pdo/Cache.php
+++ b/src/Pdo/Cache.php
@@ -47,14 +47,6 @@ class Cache extends PDO
     }
 
     /**
-     * Destructor.
-     */
-    public function __destruct()
-    {
-        return @\odbc_close($this->dbh);
-    }
-
-    /**
      * Prepares a statement for execution and returns a statement object.
      *
      * @param string $statement


### PR DESCRIPTION
When running multiple scripts connecting to a database we can run a **race condition**.  Ex: massive phpunit tests connecting to a database.

In this scenario `__destruct()` will be called while the next script will try to reuse same remaining connection resource, that is about to be mannualy closed with `odbc_close()`.

Let PHP PDO/ODBC manage connections. By default, PHP will close connection when scripts ends. But it will also try to reuse, wisely , same active connection for concurrent scripts. 

Close/open connection it is very expensive and can cause glitches, when running concurrent scripts.

---
From PHP docs  https://www.php.net/manual/en/pdo.connections.php

"Upon successful connection to the database, an instance of the PDO class is returned to your script. The connection remains active for the lifetime of that PDO object. To close the connection, you need to destroy the object by ensuring that all remaining references to it are deleted. You do this by assigning NULL to the variable that holds the object. 
**If you don't do this explicitly, PHP will automatically close the connection when your script ends**."
