### PR TITLE
Add Laravel 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.13|^2.16",
     "mockery/mockery": "^1.2",
-    "phpunit/phpunit": "^7.0|^8.4|^8.5",
+    "phpunit/phpunit": "^7.0|^8.4|^8.5|^9.0",
     "squizlabs/php_codesniffer": "^3.5"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
   ],
   "require": {
     "php": "^7.2|^7.3|^7.4",
-    "illuminate/database": "^5.0|^6.0|^7.0",
-    "illuminate/support": "^5.0|^6.0|^7.0"
+    "illuminate/database": "^5.0|^6.0|^7.0|^8.0",
+    "illuminate/support": "^5.0|^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.13|^2.16",


### PR DESCRIPTION
This adds basic Laravel 8 support by bumping the Illuminate package versions up so that the Laracache package can be installed on ^8.0 Laravel projects.

Ran the tests and all seem to be fine. I welcome any changes to the code that utilise new/different features if any.