### PR TITLE
Update dependencies to support laravel 12.x versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": "^8.2|^8.3|^8.4",
-        "illuminate/database": "^11.0",
-        "illuminate/support": "^11.0"
+        "illuminate/database": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",

--- a/src/Cache/Connection.php
+++ b/src/Cache/Connection.php
@@ -25,7 +25,7 @@ class Connection extends IlluminateConnection
 
         return ($queryGrammar)
             ? new $queryGrammar()
-            : new QueryGrammar();
+            : new QueryGrammar($this);
     }
 
     public function getDefaultSchemaGrammar()


### PR DESCRIPTION
Extended the version constraints for "illuminate/database" and "illuminate/support" to include ^12.0, ensuring compatibility with the latest releases. This update maintains support for existing versions while preparing the project for newer features and improvements in Illuminate 12.x.