### PR TITLE
Include support for Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": "^8.2|^8.3|^8.4",
-        "illuminate/database": "^11.0",
-        "illuminate/support": "^11.0"
+        "illuminate/database": "^11.0|^12.0",
+        "illuminate/support": "^11.0|^12.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",

--- a/src/Cache/Connection.php
+++ b/src/Cache/Connection.php
@@ -24,8 +24,8 @@ class Connection extends IlluminateConnection
         $queryGrammar = $this->getConfig('options.grammar.query');
 
         return ($queryGrammar)
-            ? new $queryGrammar()
-            : new QueryGrammar();
+            ? new $queryGrammar($this)
+            : new QueryGrammar($this);
     }
 
     public function getDefaultSchemaGrammar()


### PR DESCRIPTION
The version requirements for "illuminate/database" and "illuminate/support" have been broadened to incorporate ^12.0, making sure our project stays compatible with the most recent Illuminate versions. Updated Grammar Constructor to pass the connection in place as required by Laravel 12. This commit still provides support for the existing versions while gearing up for the new features and enhancements brought in Laravel 12.x.

