### PR TITLE
Fix CacheException constructor parameter type

### DIFF
--- a/src/Pdo/Cache/Exceptions/CacheException.php
+++ b/src/Pdo/Cache/Exceptions/CacheException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 class CacheException extends PDOException
 {
-    public function __construct(string $message = '', int $code = 0, Throwable $previous = null)
+    public function __construct(string $message = '', int $code = 0, Throwable $previous)
     {
         parent::__construct(
             \str_replace(['"', "\n"], ['', ' - '], $message),


### PR DESCRIPTION
PHP Deprecated:  Laracache\Pdo\Cache\Exceptions\CacheException::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in ..... jeandormehl\laracache\src\Pdo\Cache\Exceptions\CacheException.php on line 10